### PR TITLE
Correcciones a La tiranía de la falta de estructuras

### DIFF
--- a/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
+++ b/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
@@ -279,9 +279,9 @@ integrantes de la estructura informal y eventualmente se es iniciada o
 descartada.  Si la sororidad no está políticamente al tanto de este
 proceso como para llevarlo a cabo activamente, puede ser iniciado por la
 ajena casi de la misma forma en que una se une a un club privado.
-Encuentra una esponsor, es decir una integrante de la élite respetada
+Encuentra una sponsor, es decir una integrante de la élite respetada
 internamente, para cultivar activamente su amistad.  Eventualmente la
-esponsor nos hará entrar al círculo.
+sponsor nos hará entrar al círculo.
 
 [^sororidad]: Una organización social para estudiantes muy común en las
 universidades estadounidenses. Ver [https://es.wikipedia.org/wiki/Fraternidades_y_sororidades](https://es.wikipedia.org/wiki/Fraternidades_y_sororidades)
@@ -384,9 +384,9 @@ cometer todos los pecados individualistas de los que ha sido acusada.
 
 # Impotencia política
 
-Los grupos desestructurados quizas sean muy efectivos para hacer que las
+Los grupos desestructurados quizás sean muy efectivos para hacer que las
 mujeres hablen sobre sus vidas; pero no son muy buenos para lograr que
-se hagan las cosas. Aquí es cuando las personas se cansan de "solo
+se hagan las cosas. Esto es cuando las personas se cansan de "solo
 hablar" y quieren hacer algo más que estar dando vueltas sin hacer nada
 pero en grupo, a menos que cambien la naturaleza de su operación.
 Ocasionalmente, la estructura informal desarrollada coincide con una
@@ -410,8 +410,8 @@ para asegurar que las participantes tengan un "lenguaje común" para
 interactuar. Las personas de diferentes contextos pueden enriquecer un
 grupo de toma de conciencia donde cada una puede aprender de las
 experiencias de otras, pero una diversidad muy amplia en un grupo
-orientado a tareas significa que las participantes no se van a entender
-entre sí constantemente.  Personas muy diversas interpretan las palabras
+orientado a tareas significa que las participantes van a malinterpretarse
+constantemente.  Personas muy diversas interpretan las palabras
 y las acciones de formas distintas.  Tienen distintas expectativas sobre
 el comportamiento de las demás y juzgan los resultados bajo diferentes
 criterios.  Si todas se conocen entre sí lo suficiente como para
@@ -423,7 +423,7 @@ que nadie esperaba.
 a todas, las opiniones chequeadas, el trabajo dividido y la
 participación asegurada en las decisiones relevantes. Esto sólo es
 posible si el grupo es pequeño y la personas viven prácticamente juntas
-la mayoría de las etapas cruciales de las tareas. No hace falta decir
+durante la mayoría de las etapas cruciales de las tareas. No hace falta decir
 que el número de interacciones necesarias para involucrar a todas
 aumenta geométricamnete con el número de participantes. Esto
 inevitablemente limita el grupo de participantes a unas cinco, o excluye
@@ -444,13 +444,15 @@ grupos pequeños, esto no es posible en los grandes. En consecuencia,
 porque el movimiento mayor en la mayoría de las ciudades es tan
 desestructurado como los grupos de difusión individuales, no son mucho
 más eficaces que grupos separados en distintas tareas específicas. La
-estructura informal es raramente lo bastante unida o lo suficientemente
-en contacto con la gente para ser capaces de operar efectivamente.
+estructura informal es raramente lo bastante unida o está lo suficientemente
+en contacto con la gente para ser capaz de operar efectivamente.
 Entonces el movimiento genera mucha tracción y pocos resultados.
 Desafortunadamente, las consecuencias de tal tracción no son tan inocuas
 como sus resultados y su víctima es el movimiento mismo.
 
-[^serendipia]: [https://es.wikipedia.org/wiki/Serendipia](https://es.wikipedia.org/wiki/Serendipia)
+[^serendipia]: Una serendipia es un descubrimiento o un hallazgo afortunado e
+inesperado que se produce cuando se está buscando otra cosa distinta. Ver más
+en [https://es.wikipedia.org/wiki/Serendipia](https://es.wikipedia.org/wiki/Serendipia)
 
 Algunos grupos se han convertido en proyectos de acción local porque no
 se involucra a muchas personas y trabajan en pequeña escala. Pero esta
@@ -458,8 +460,8 @@ forma restringe la actividad del movimiento al nivel local; no se puede
 hacer de la misma forma en lo nacional o regional. Además, para
 funcionar bien los grupos por lo general deben recortarse a ese grupo
 informal de amigas que hacían funcionar las cosas desde un principio.
-Esto excluye a muchas mujeres de participar. Mientras la única manera de
-que las mujeres pueden participar en el movimiento sea a través de la
+Esto excluye de participar a muchas mujeres. Mientras la única manera de
+que las mujeres puedan participar en el movimiento sea a través de la
 pertenencia a un pequeño grupo, las no gregarias están en una desventaja
 distintiva. Mientras los grupos de amigas sean los medios principales de
 la organización de las actividades, el elitismo seguirá
@@ -470,7 +472,7 @@ dedicarse, el mero acto de estar unidos se convierte en la razón de
 estar juntos. Cuando un grupo no tiene tareas específicas (y la toma de
 conciencia es una tarea), las personas vuelcan sus energías a controlar
 a otras dentro de los grupos. Esto no se hace tanto por el deseo
-malicioso de manipular a otras (aunque a veces lo es) sino por una falta
+malicioso de manipular a otras (aunque a veces sea así) sino por una falta
 de algo mejor que hacer con sus talentos. Las personas capaces con
 tiempo en sus manos y una necesidad de justificar su unión pone sus
 esfuerzos en el control personal y pasa su tiempo criticando las
@@ -478,8 +480,8 @@ personalidades de otras integrantes del grupo. Las peleas internas y los
 juegos de poder personal dominan el día. Cuando un grupo está
 involucrado en una tarea, hay quienes aprenden a llevarse bien con otras
 tal como son y dejar de lado las diferencias personales por el bien del
-objetivo mayor. Existen límites a la compulsión de remodelar a toda
-persona a nuestra imagen de lo que deben ser.
+objetivo mayor. Se ponen límites a la compulsión de remodelar a toda
+persona según nuestra imagen de lo que deberían ser.
 
 El fin de la toma de conciencia deja gente sin lugar donde ir y la falta
 de estructura los deja sin forma de llegar allí. Las mujeres del
@@ -496,7 +498,7 @@ proyectos grupales que les interesen.
 Muchas se dirigen a otras organizaciones políticas para encontrar el
 tipo de actividad efectiva y estructurada que no fueron capaces de
 encontrar en el movimiento de mujeres. Las organizaciones políticas que
-ven la liberación de las mujeres como solo una de muchas cuestiones a
+ven la liberación de las mujeres como sólo una de muchas cuestiones a
 las cuales las mujeres deben dedicar su tiempo encuentran en el
 movimiento un vasto campo de reclutamiento de nuevas integrantes. No hay
 necesidad de "infiltrar" tales organizaciones (aunque esto no se
@@ -511,8 +513,8 @@ convierten en el marco de nuevas estructuras informales. Estas redes de
 amistad están basadas en sus prácticas políticas no feministas en lugar
 de las características discutidas anteriormente, aunque operan en la
 misma manera. Como esas mujeres comparten valores en común, ideas y
-orientaciones políticas, también se vuelven informales, no planificadas,
-no seleccionadas, élites sin responsabilidad --intenten serlo o no.
+orientaciones políticas, también se vuelven élites informales, no planificadas,
+no seleccionadas, sin responsabilidad --intenten serlo o no.
 
 Estas nuevas élites informales son a menudo percibidas como amenazas por
 las antiguas élites informales previamente desarrolladas dentro de los
@@ -532,13 +534,13 @@ volverse "públicas" y esta posibilidad está cargada con muchas
 implicaciones peligrosas. Por lo tanto, para mantener su propio poder,
 es más fácil racionalizar la exclusion de las integrantes de la otra
 estructura informal por medios como el hostigamiento a las
-izquierdistas, a las reformistas, las lesbianas o las heterosexuales. La
+izquierdistas, las reformistas, las lesbianas o las heterosexuales. La
 única alternativa es estructurar formalmente al grupo de tal manera que
 la estructura de poder original se institucionalice. Esto no siempre es
 posible. Si las élites informales han estado bien estructuradas y han
 ejercido una buena cantidad de poder en el pasado, tal tarea es
-factible. Estos grupos tienen una historia de efectividad política, así
-como la estrechez de su estructura informal se ha demostrado como un
+factible. Estos grupos tienen una historia de efectividad política, ya que
+lo ajustado de su estructura informal ha demostrado ser un
 sustituto adecuado de una estructura formal. Convertirse en un grupo
 estructurado no altera mucho su forma de operar, aunque la
 institucionalización del poder estructurado lo abre a un desafío formal.
@@ -570,7 +572,7 @@ prioridades. No tienen siquiera una manera de decidir lo que son.
 
 Cuanto más falto de estructura es un movimiento, menos control tiene
 sobre las direcciones en las que se desarrolla y las acciones políticas
-en las que participa. Esto no quiere decir que sus ideas no se difunden.
+en las que participa. Esto no quiere decir que sus ideas no se difundan.
 Dado un cierto interés de los medios de comunicación y la adecuación de
 las condiciones sociales, las ideas serán todavía difundidas
 ampliamente. Pero la difusión de las ideas no significa que sean
@@ -579,23 +581,23 @@ que puedan aplicarse individualmente podrán ser practicadas, pero en la
 medida en que requieran poder político coordinado para ser
 implementadas, no lo serán.
 
-Mientras que los movimientos de liberación de las mujeres se dedicaban a
+Mientras los movimientos de liberación de las mujeres se dediquen a
 una forma de organización que hace hincapié en grupos de discusión
-pequeños e inactivos entre amigas, el peor problema de la falta de
-estructura no se sentía. Pero este estilo de organización tiene sus
+pequeños e inactivos entre amigas, los peores problemas de la falta de
+estructura no se sentirán. Pero este estilo de organización tiene sus
 límites; es políticamente ineficaz, exclusivo y discriminatorio contra
 aquellas mujeres que no son o no pueden ser atadas a esas redes de
-amistad. Aquellas que no caben en lo que ya existe porque su clase,
+amistad. Aquellas que no encajan en lo que ya existe por su clase,
 raza, ocupación, educación, situación parental o matrimonial,
 personalidad, etc., serán inevitablemente desalentadas de intentar
-participar. aquellas que encajen desarrollarán intereses personales en
+participar. Aquellas que encajen desarrollarán intereses personales en
 mantener las cosas tal y como están.
 
 Los intereses personales de los grupos informales serán sustentados por
 la estructura informal existente y el movimiento no tendrá manera de
 determinar quién ejercerá poder dentro suyo. Si el movimiento continua
-deliberadamente en no seleccionar quién ejercerá poder, no lo podrá
-abolir. Todo lo que hace es abdicar el derecho a exigir que las que
+deliberadamente no seleccionando quién ejercerá poder, no podrá
+abolir ese poder. Todo lo que hace es abdicar el derecho a exigir que las que
 ejercen poder e influencia sean responsables por ello. Si el movimiento
 continua manteniendo el poder tan difuso como sea posible porque sabe
 que no puede demandar responsabilidad de aquellas que lo tienen, evita
@@ -622,7 +624,7 @@ regional y nacionalmente.
 # Principios de estructuración democrática
 
 Una vez que el movimiento ya no se aferre tenazmente a la ideología de
-la "falta de estructura," es libre de desarrollar esas formas de
+la "falta de estructura", es libre de desarrollar esas formas de
 organización más adecuadas para un funcionamiento saludable. Esto no
 significa que debemos ir al otro extremo e imitar ciegamente las formas
 tradicionales de organización. Pero tampoco debemos rechazarlas
@@ -634,9 +636,9 @@ diferentes tipos de estructura y desarrollar una variedad de técnicas
 para usar en diferentes situaciones. El sistema de sorteo es una de esas
 ideas que emergieron del movimiento. No es aplicable a todas las
 situaciones, pero es útil en algunas. Otras ideas sobre estructuración
-son necesarias. Pero antes que podamos proceder a experimentar
-inteligentemente, debemos aceptar que no hay nada inherente malo en la
-estructura misma -- solo exceso de uso.
+son necesarias. Pero antes de que podamos proceder a experimentar
+inteligentemente, debemos aceptar que no hay nada inherentemente malo en la
+estructura misma -- sólo exceso de uso.
 
 Mientras nos involucramos en este proceso de prueba y error, hay algunos
 principios que podemos mantener en mente que son esenciales para una
@@ -654,7 +656,7 @@ fácilmente ignorado.
 autoridad sean responsables hacia las que las seleccionaron. Esta es la
 forma en que el grupo tiene control sobre las personas en posiciones de
 autoridad. Las personas pueden ejercer poder pero es el grupo el que
-tiene la última palabra sobre como será ejercido.
+tiene la última palabra sobre cómo será ejercido.
 
 #. La distribución de la autoridad entre tantas personas como sea
 razonablemente posible. Esto previene el monopolio del poder y requiere
@@ -665,16 +667,16 @@ tanto aprender diferentes habilidades.
 
 #. La rotación de tareas entre personas. Las responsabilidades que se
 mantienen demasiado tiempo por una sola persona, formal o informalmente,
-terminan siendo vistos como su "propiedad" y no resulta fácil renunciar
-a ellos, o volver a ser controlados por el grupo. Por el contrario, si
+terminan siendo vistas como su "propiedad" y no resulta fácil renunciar
+a ellas, o volver a controlarlas desde el grupo. Por el contrario, si
 las tareas son rotadas con demasiada frecuencia las personas no tienen
 tiempo de aprender bien su trabajo y adquirir el sentido de satisfacción
 por hacerlo bien.
 
 #. Asignación de tareas en base a criterios racionales. Seleccionar a
 alguien para una posición porque es del agrado del grupo o dándole
-trabajo pesado porque les disgusta no sirve al grupo ni a la persona en
-el largo plazo. Capacidad, interés y responsabilidad deben ser las
+trabajo pesado porque les disgusta no sirve en el largo plazo ni al grupo ni a
+la persona. Capacidad, interés y responsabilidad deben ser las
 principales preocupaciones para tal selección. Las personas deben tener
 una oportunidad para aprender habilidades que no tienen, pero esto se
 hace mejor a través de algún tipo de programa de "aprendizaje" en lugar
@@ -699,13 +701,13 @@ que mantiene un monopolio sobre un recurso necesario (como una imprenta
 propiedad del marido o un cuarto oscuro) puede influir indebidamente en
 su uso. Las habilidades y la información también son recursos. Las
 habilidades de las integrantes están equitativamente disponibles sólo
-cuando están dispuestas a enseñar lo que saben a las demás.
+cuando estas están dispuestas a enseñar lo que saben a las demás.
 
 Cuando se aplican estos principios, se asegura que cualquier estructura
 desarrollada por diferentes grupos del movimiento será controlada por el
-grupo y responsable ante este. El grupo de personas en posiciones de
+grupo y responsable ante éste. El grupo de personas en posiciones de
 autoridad será difuso, flexible, abierto y temporal. No van a estar en
-una posición tan fácil de institucionalizar su poder porque las
+una posición de institucionalizar su poder tan fácilmente porque las
 decisiones finales serán tomadas por el grupo en general. El grupo
 tendrá la facultad de determinar quién ejercerá la autoridad dentro
 suyo.

--- a/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
+++ b/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
@@ -188,7 +188,7 @@ poder sobre el grupo, formando facciones o una abandonando la
 competencia y dejando a la otra como la élite.  En un grupo con
 estructura, dos o más de estas redes de amigas usualmente compiten entre
 sí por el poder formal.  Esta es la situación más saludable, porque las
-otras miembros están en posición de arbitrar entre ambos grupos en
+otras integrantes están en posición de arbitrar entre ambos grupos en
 competencia por el poder y por lo tanto hacer demandas a aquellas a las
 que se les dio lealtad temporal.
 
@@ -210,7 +210,7 @@ las mujeres, pero lo han vuelto más difícil.
 
 Que las élites sean informales no quiere decir que sean invisibles.  En
 cualquier reunión de un grupo pequeño puede notarse quién influencia a
-quién.  Las miembros de un grupo de amistad se relacionarán más entre sí
+quién.  Las integrantes de un grupo de amistad se relacionarán más entre sí
 que con otras personas.  Prestan más atención e interrumpen menos,
 repiten los mismos puntos y ceden amistosamente. Además tienden a
 ignorar o discutir con las "ajenas" cuya aprobación es innecesaria para
@@ -262,7 +262,7 @@ cualquier movimiento u organización debe usar para ser políticamente
 efectivo.
 
 Los criterios de participación pueden diferir de grupo a grupo, pero los
-medios para convertirse en miembro de la élite informal, si una cumple
+medios para convertirse en integrante de la élite informal, si una cumple
 con esos criterios, son casi siempre los mismos.  La única diferencia
 depende de si una pertenece al grupo desde el principio o se une más
 tarde.  Si se involucra desde el principio lo importante es que todas
@@ -275,11 +275,11 @@ las tácticas más exitosas de este mantenimiento es el reclutamiento
 continuo de personas que "encajan".  Se forma parte de una élite de la
 misma forma que se ingresa a una sororidad[^sororidad].  Si una es
 percibida como una incorporación potencial, se es preparada por las
-miembros de la estructura informal y eventualmente se es iniciada o
+integrantes de la estructura informal y eventualmente se es iniciada o
 descartada.  Si la sororidad no está políticamente al tanto de este
 proceso como para llevarlo a cabo activamente, puede ser iniciado por la
 ajena casi de la misma forma en que una se une a un club privado.
-Encuentra una esponsor, es decir una miembro de la élite respetada
+Encuentra una esponsor, es decir una integrante de la élite respetada
 internamente, para cultivar activamente su amistad.  Eventualmente la
 esponsor nos hará entrar al círculo.
 
@@ -299,7 +299,7 @@ Aunque esta disección del proceso de formación de élites dentro de
 grupos pequeños ha sido crítico, no está hecha bajo la creencia de que
 estas estructuras informales son inevitablemente malas, sino que son
 inevitables.  Todos los grupos crean estructuras informales como
-resultado de los patrones de interacción entre las miembros del grupo.
+resultado de los patrones de interacción entre las integrantes del grupo.
 Tales estructuras informales pueden realizar cosas valiosas pero solo
 los grupos sin estructura son gobernados por ellas.  Cuando las élites
 informales se combinan con el mito de la "falta de estructura" no puede
@@ -430,7 +430,7 @@ inevitablemente limita el grupo de participantes a unas cinco, o excluye
 a algunas de algunas decisiones. Los grupos exitosos pueden ser tan
 grandes como diez o quince personas, pero sólo cuando están de hecho
 compuestos por varios subgrupos más pequeños que realizan partes
-específicas de las tareas y cuyas miembros se solapan entre sí de modo
+específicas de las tareas y cuyas integrantes se solapan entre sí de modo
 que el conocimiento de lo que los diferentes grupos están haciendo puede
 ser transmitido con facilidad.
 
@@ -474,7 +474,7 @@ malicioso de manipular a otras (aunque a veces lo es) sino por una falta
 de algo mejor que hacer con sus talentos. Las personas capaces con
 tiempo en sus manos y una necesidad de justificar su unión pone sus
 esfuerzos en el control personal y pasa su tiempo criticando las
-personalidades de otras miembros del grupo. Las peleas internas y los
+personalidades de otras integrantes del grupo. Las peleas internas y los
 juegos de poder personal dominan el día. Cuando un grupo está
 involucrado en una tarea, hay quienes aprenden a llevarse bien con otras
 tal como son y dejar de lado las diferencias personales por el bien del
@@ -498,7 +498,7 @@ tipo de actividad efectiva y estructurada que no fueron capaces de
 encontrar en el movimiento de mujeres. Las organizaciones políticas que
 ven la liberación de las mujeres como solo una de muchas cuestiones a
 las cuales las mujeres deben dedicar su tiempo encuentran en el
-movimiento un vasto campo de reclutamiento de nuevas miembros. No hay
+movimiento un vasto campo de reclutamiento de nuevas integrantes. No hay
 necesidad de "infiltrar" tales organizaciones (aunque esto no se
 excluye). El deseo de una actividad política significativa generada en
 las mujeres por su devenir en el movimiento de liberación de las mujeres
@@ -530,7 +530,7 @@ Muchas de estas élites informales estuvieron ocultas bajo la bandera del
 efectivamente la competencia de otra estructura informal, tendrían que
 volverse "públicas" y esta posibilidad está cargada con muchas
 implicaciones peligrosas. Por lo tanto, para mantener su propio poder,
-es más fácil racionalizar la exclusion de las miembros de la otra
+es más fácil racionalizar la exclusion de las integrantes de la otra
 estructura informal por medios como el hostigamiento a las
 izquierdistas, a las reformistas, las lesbianas o las heterosexuales. La
 única alternativa es estructurar formalmente al grupo de tal manera que
@@ -563,7 +563,7 @@ izquierdistas son simplemente las únicas organizaciones capaces de
 montar una campaña nacional. La multitud de grupos de liberación de las
 mujeres no estructurados pueden optar por apoyar o no las campañas
 nacionales, pero son incapaces de montar las suyas propias. Así sus
-miembros se vuelven las tropas bajo el liderazgo de las organizaciones
+integrantes se vuelven las tropas bajo el liderazgo de las organizaciones
 estructuradas. Los grupos declaradamente no estructurados no tienen
 manera de recurrir a los vastos recursos del movimiento para apoyar sus
 prioridades. No tienen siquiera una manera de decidir lo que son.
@@ -694,11 +694,11 @@ participe. Cuanto más se sabe acerca de cómo funcionan las cosas y
 aquello que está sucediendo, más políticamente eficaces se puede ser.
 
 #. Igualdad de acceso a los recursos que necesite el grupo. Esto no
-siempre es perfectamente posible, pero se debería procurar. Una miembro
+siempre es perfectamente posible, pero se debería procurar. Una integrante
 que mantiene un monopolio sobre un recurso necesario (como una imprenta
 propiedad del marido o un cuarto oscuro) puede influir indebidamente en
 su uso. Las habilidades y la información también son recursos. Las
-habilidades de las miembros están equitativamente disponibles sólo
+habilidades de las integrantes están equitativamente disponibles sólo
 cuando están dispuestas a enseñar lo que saben a las demás.
 
 Cuando se aplican estos principios, se asegura que cualquier estructura

--- a/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
+++ b/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
@@ -644,7 +644,7 @@ Mientras nos involucramos en este proceso de prueba y error, hay algunos
 principios que podemos mantener en mente que son esenciales para una
 estructuración democrática y también son políticamente efectivos:
 
-#. Delegación de autoridad específica para que personas específicas
+#. __Delegación__ de autoridad específica para que personas específicas
 realicen tareas específicas mediante procedimientos democráticos.  Dejar
 que la gente asuma trabajos o tareas por su cuenta significa que no se
 llevarán a cabo de forma fiable. Si se seleccionan las personas para
@@ -653,19 +653,19 @@ de hacerlo, quiere decir que han hecho un compromiso que no podrá ser
 fácilmente ignorado.
 
 #. Requerir que todas aquellas a quienes se les ha delegado una
-autoridad sean responsables hacia las que las seleccionaron. Esta es la
+autoridad sean __responsables__ hacia las que las seleccionaron. Esta es la
 forma en que el grupo tiene control sobre las personas en posiciones de
 autoridad. Las personas pueden ejercer poder pero es el grupo el que
 tiene la última palabra sobre cómo será ejercido.
 
-#. La distribución de la autoridad entre tantas personas como sea
+#. La __distribución__ de la autoridad entre tantas personas como sea
 razonablemente posible. Esto previene el monopolio del poder y requiere
 que aquellas en posiciones de autoridad consulten con muchas otras
 durante el proceso de ejercerlo. También da a muchas personas la
 oportunidad de tener responsabilidad sobre tareas específicas y por lo
 tanto aprender diferentes habilidades.
 
-#. La rotación de tareas entre personas. Las responsabilidades que se
+#. La __rotación__ de tareas entre personas. Las responsabilidades que se
 mantienen demasiado tiempo por una sola persona, formal o informalmente,
 terminan siendo vistas como su "propiedad" y no resulta fácil renunciar
 a ellas, o volver a controlarlas desde el grupo. Por el contrario, si
@@ -673,7 +673,7 @@ las tareas son rotadas con demasiada frecuencia las personas no tienen
 tiempo de aprender bien su trabajo y adquirir el sentido de satisfacción
 por hacerlo bien.
 
-#. Asignación de tareas en base a criterios racionales. Seleccionar a
+#. __Asignación__ de tareas en base a criterios racionales. Seleccionar a
 alguien para una posición porque es del agrado del grupo o dándole
 trabajo pesado porque les disgusta no sirve en el largo plazo ni al grupo ni a
 la persona. Capacidad, interés y responsabilidad deben ser las
@@ -687,7 +687,7 @@ habilidades. Las mujeres han sido castigadas por ser competentes durante
 la mayor parte de la historia humana; el movimiento no necesita que
 repetir este proceso.
 
-#. Difusión de información a todo el mundo con la mayor frecuencia
+#. __Difusión de información__ a todo el mundo con la mayor frecuencia
 posible. La información es poder. El acceso a la información mejora el
 poder de cada una. Cuando una red informal difunde nuevas ideas e
 información entre ellas mismas por fuera del grupo, ya están
@@ -695,7 +695,7 @@ participando en el proceso de formación de opinión --sin que el grupo
 participe. Cuanto más se sabe acerca de cómo funcionan las cosas y
 aquello que está sucediendo, más políticamente eficaces se puede ser.
 
-#. Igualdad de acceso a los recursos que necesite el grupo. Esto no
+#. __Igualdad de acceso a los recursos__ que necesite el grupo. Esto no
 siempre es perfectamente posible, pero se debería procurar. Una integrante
 que mantiene un monopolio sobre un recurso necesario (como una imprenta
 propiedad del marido o un cuarto oscuro) puede influir indebidamente en

--- a/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
+++ b/_posts/2015-01-24-la_tirania_de_la_falta_de_estructuras.markdown
@@ -8,11 +8,11 @@ slider: "assets/covers/slider_la_tirania_de_la_falta_de_estructuras.png"
 
 La versión más temprana de este artículo fue presentada como una charla
 en una conferencia organizada por el Sindicato por los Derechos de la
-Mujer Sureña [Southern Female Rights Union], sostenida en Beulah,
+Mujer Sureña [Southern Female Rights Union], que tuvo lugar en Beulah,
 Mississippi en mayo de 1970.  Fue transcrito para Notas del Tercer Año
 (1971) pero las editoras no lo usaron.  También fue enviado a varias
-publicaciones del movimiento, pero sólo uno pidió permiso para
-publicarlo; otros lo hicieron sin permiso.  La primera publicación
+publicaciones del movimiento, pero sólo una pidió permiso para
+publicarlo; otras lo hicieron sin permiso.  La primera publicación
 oficial fue en el Volumen 2, Número 1 de "La Segunda Ola" (1972).  Esta
 versión temprana fue firmada como Joreen.  Otras versiones fueron
 publicadas en la "Revista de Sociología" de Berkeley, Volumen 17,
@@ -62,8 +62,8 @@ voluntad de cambiar su estructura a medida que cambiaban sus tareas.
 Las mujeres habían aceptado profundamente la idea de la "falta de
 estructuras" sin darse cuenta de las limitaciones de sus usos.  Las
 personas intentaban utilizar el grupo "sin estructura" y la conferencia
-informal para propósitos para los que no eran adecuados por una
-confianza ciega en que cualquier otro medio no podría ser otra cosa que
+informal para propósitos para los que no eran adecuados, por una
+confianza ciega en que cualquier otro medio no podría ser más que
 opresivo.
 
 Para que el movimiento crezca más allá de los estadios elementales de su
@@ -102,19 +102,19 @@ hacer_ no le impide al económicamente poderoso establecer control sobre
 salarios, precios y distribución de bienes; solo impide al gobierno
 hacerlo. Es por esto que la "falta de estructura" deriva en una forma de
 esconder el poder y dentro de los movimientos feministas es usualmente
-promovido por aquellas que son las más poderosas (sean o no concientes
+promovido por aquellas que son las más poderosas (sean o no conscientes
 de su poder). Mientras que la estructura del grupo sea informal, las
 reglas de cómo se toman las decisiones son conocidas por unas pocas
 personas y el reconocimiento del poder está limitado a aquellas que
 saben las reglas. Aquellas que no saben las reglas y no son elegidas
 para iniciarse, deben permanecer en estado de confusión, o sufrir
 delirios paranoicos de que algo está pasando, aunque no están del todo
-concientes de qué se trata.
+conscientes de qué se trata.
 
 Para que todas tengan la oportunidad de participar en un grupo
 determinado y ser parte de sus actividades, la estructura debe ser
-explícita, no implícita. Las reglas de la toma de decisiones deben estar
-abiertas y disponibles para todo el mundo y esto sólo puede suceder si
+explícita, no implícita. Las reglas de la toma de decisiones deben ser
+abiertas y estar disponibles para todo el mundo y esto sólo puede suceder si
 se formalizan. Esto no significa que la formalización de la estructura
 de un grupo vaya a destruir su estructura informal. Por lo general, no
 lo hace. Pero sí impide que la estructura informal tenga el control
@@ -126,11 +126,11 @@ que podemos decidir es si el grupo tendrá una estructura formalizada o
 no. Por lo tanto, no utilizaremos más este concepto, excepto para
 referirnos a la idea de lo que representa. Por no estructurado nos
 referiremos a aquellos grupos que no han sido estructurados
-deliberadamente de una manera particular. Por organizado nos referiremos
-a aquellos que poseen estructura. Un grupo estructurado siempre tiene
+deliberadamente de una manera particular. Por estructurados nos referiremos
+a los que sí lo han sido. Un Grupo Estructurado siempre tiene
 una estructura formal, pero también puede tener una informal o
-encubierta. Es esta estructura informal, sobre todo en los grupos no
-estructurados, lo que constituye la base para las élites.
+encubierta. Es esta estructura informal, sobre todo en los Grupos No
+Estructurados, lo que constituye la base para las élites.
 
 
 # La naturaleza del elitismo
@@ -143,14 +143,14 @@ generalmente se refiere a personas, a pesar de que las características
 personales y actividades de aquellas a las que se refiere pueden diferir
 ampliamente: una persona nunca puede ser elitista individualmente porque
 el término "élite" se aplica únicamente a grupos. Una sola persona,
-independientemente de cuánto se la reconozca, nunca puede ser una élite.
+independientemente de cuán reconocida sea, nunca puede ser una élite.
 
-La forma correcta es que una élite hace referencia a un pequeño grupo de
+Correctamente, una élite se refiere a un pequeño grupo de
 personas que tienen poder sobre un grupo más grande del que son parte,
 usualmente sin responsabilidad directa hacia ese grupo y normalmente sin
 su conocimiento o consentimiento. Una persona se convierte en elitista
 siendo parte o promoviendo el gobierno de este pequeño grupo, sea o no
-reconocido. La notoriedad no es la definicion de una elitista. Las
+reconocido. La notoriedad no una definicion de elitista. Las
 élites más insidiosas son usualmente dirigidas por personas no conocidas
 por el público general.  Las elitistas inteligentes son lo
 suficientemente listas como para no volverse muy reconocidas; cuando son
@@ -168,8 +168,8 @@ fenómenos lo que crea élites en cualquier grupo y las hace tan difíciles
 de romper.
 
 Estos grupos de amistad funcionan como redes de comunicación fuera de
-cualquier canal regular montado por un grupo para ese tipo comunicación.
-Si ningún canal es montado, funcionan como la única red de comunicación.
+cualquier canal regular montado por un grupo para ese tipo de comunicación.
+Si no hay canales montados, funcionan como la única red de comunicación.
 Debido a que las personas son amigas, a que usualmente comparten los
 mismos valores y orientaciones y a que hablan entre sí socialmente y se
 consultan cuando tienen que tomar decisiones comunes, las personas
@@ -178,10 +178,10 @@ que no. A su vez es raro que un grupo no establezca alguna red de
 comunicación informal a través de las amigas que haya dentro.
 
 Algunos grupos, dependiendo de su tamaño, pueden tener más de una de
-estas redes informales de comunicación. Las redes pueden incluso
-solaparse. Cuando solo existe una red, es la red de la élite sin
-estructura, aun cuando sus participantes no quieran serlo.  Si hay una
-sola red en un grupo con estructura, puede o no ser de una élite
+estas redes informales de comunicación. Las redes incluso pueden
+solaparse. Cuando sólo existe una de estas redes, es la élite del Grupo No
+Estructurado, aun cuando sus participantes no quieran serlo.  Si hay una
+sola red en un Grupo Estructurado, puede o no ser de una élite
 dependiendo de su composición y de la naturaleza de la estructura
 formal.  Si existen dos o más redes de amigas, podrían competir por el
 poder sobre el grupo, formando facciones o una abandonando la
@@ -198,15 +198,15 @@ movimiento feminista, ni tampoco un fenómeno nuevo para las mujeres.
 Tales relaciones informales han excluido a las mujeres durante siglos,
 impidiéndoles participar en grupos de los que eran parte.  En cualquier
 profesión u organización estas redes son las que crean la mentalidad de
-vestuario y los lazos de "la vieja escuela" que han prevenido
-efectivamente que las mujeres de un grupo (así como a otros hombres
+"vestuario" y los lazos de "la vieja escuela", que han prevenido
+efectivamente que las mujeres como un grupo (así como algunos hombres
 individualmente) tengan igual acceso a las fuentes de poder y
 reconocimiento social.  En el pasado, los movimientos feministas han
 puesto mucha energía en la formalización de las estructuras de toma de
 decisiones y selección, de forma que la exclusión de las mujeres pueda
 ser confrontada directamente.  Como todas sabemos, estos esfuerzos no
-han prevenido que las redes informales masculinas sigan discriminando a
-las mujeres, pero las han vuelto más dificultosas.
+han evitado que las redes informales masculinas sigan discriminando a
+las mujeres, pero lo han vuelto más difícil.
 
 Que las élites sean informales no quiere decir que sean invisibles.  En
 cualquier reunión de un grupo pequeño puede notarse quién influencia a
@@ -225,7 +225,7 @@ Como los grupos del movimiento no han tomado decisiones concretas sobre
 quién ejerce el poder dentro suyo, existen diferentes criterios en uso.
 Muchos de estos criterios se basan en las características femeninas
 tradicionales.  Por ejemplo, en los primeros días del movimiento, el
-matrimonio era un pre-requisito para participar en la élite informal.
+matrimonio era un prerrequisito para participar en la élite informal.
 Como se les había enseñado tradicionalmente, las mujeres casadas se
 relacionaban entre sí, percibiendo a las solteras como una amenaza. En
 muchas ciudades, este criterio se refinó para incluir sólo a mujeres
@@ -252,28 +252,28 @@ particularmente si se tiene una "carrera", no ser "amable" y ser soltera
 (es decir, no ser ni activamente heterosexual ni homosexual).
 
 Podrían incluirse otros criterios, pero todos tienen temas en común.
-Las características que son pre-requisito para participar en las élites
-informales del movimiento y por lo tanto ejercer poder, conciernen a su
-historia, personalidad o disponibilidad de tiempo.  No incluye
+Las características que son prerrequisito para participar en las élites
+informales del movimiento y por lo tanto ejercer poder, conciernen al
+origen, personalidad o disponibilidad de tiempo de cada una.  No incluyen
 competencia, dedicación al feminismo, talentos o contribución potencial
 al movimiento.  Los primeros son los criterios que una utiliza
 usualmente para elegir amigas.  Los segundos son los criterios que
 cualquier movimiento u organización debe usar para ser políticamente
 efectivo.
 
-El criterio de participación puede diferir de grupo a grupo, pero los
-medios para convertirse en miembro de la élite informal, si se cumple
+Los criterios de participación pueden diferir de grupo a grupo, pero los
+medios para convertirse en miembro de la élite informal, si una cumple
 con esos criterios, son casi siempre los mismos.  La única diferencia
-depende de si se pertenece al grupo desde el principio o se une más
+depende de si una pertenece al grupo desde el principio o se une más
 tarde.  Si se involucra desde el principio lo importante es que todas
 las amigas personales también se unan.  Si no se conoce bien a nadie,
 entonces hay que formar amistades con un grupo selecto de forma
 deliberada y establecer los patrones de interacción informal que son
 cruciales para la creación de un estructura informal.  Una vez que se
-forman estos patrones informales funcionan para auto-mantenerse y una de
+forman, estos patrones informales funcionan para auto-mantenerse y una de
 las tácticas más exitosas de este mantenimiento es el reclutamiento
 continuo de personas que "encajan".  Se forma parte de una élite de la
-misma forma que se ingresa a una sororidad[^sororidad].  Si se es
+misma forma que se ingresa a una sororidad[^sororidad].  Si una es
 percibida como una incorporación potencial, se es preparada por las
 miembros de la estructura informal y eventualmente se es iniciada o
 descartada.  Si la sororidad no está políticamente al tanto de este
@@ -283,7 +283,8 @@ Encuentra una esponsor, es decir una miembro de la élite respetada
 internamente, para cultivar activamente su amistad.  Eventualmente la
 esponsor nos hará entrar al círculo.
 
-[^sororidad]: [https://es.wikipedia.org/wiki/Fraternidades_y_sororidades](https://es.wikipedia.org/wiki/Fraternidades_y_sororidades)
+[^sororidad]: Una organización social para estudiantes muy común en las
+universidades estadounidenses. Ver [https://es.wikipedia.org/wiki/Fraternidades_y_sororidades](https://es.wikipedia.org/wiki/Fraternidades_y_sororidades)
 
 Todos estos procedimientos toman tiempo, así que si una trabaja a tiempo
 completo o tiene otro compromiso similar, resulta imposible participar,
@@ -295,7 +296,7 @@ exceso de trabajo.  Tener un proceso establecido para la toma de
 decisiones asegura que todas pueden participar en alguna medida.
 
 Aunque esta disección del proceso de formación de élites dentro de
-grupos pequeños ha sido crítico, no está hecha bajo la creencia que
+grupos pequeños ha sido crítico, no está hecha bajo la creencia de que
 estas estructuras informales son inevitablemente malas, sino que son
 inevitables.  Todos los grupos crean estructuras informales como
 resultado de los patrones de interacción entre las miembros del grupo.
@@ -313,24 +314,24 @@ importantes.  Mientras el movimiento no haga cosas importantes esto no
 es un problema.  Pero si este desarrollo no se corta en el estadio
 preliminar, alterará sus capacidades.  La segunda consecuencia es que
 las estructuras informales no tienen obligaciones con el grupo.  El
-poder no se les ha dado desde el grupo, por lo que no se lo puede
+poder no se les ha dado, por lo que no se les puede
 quitar.  Su influencia no está basada en lo que hacen por el grupo, por
 lo que no puede ser influenciada por este.  Esto no necesariamente hace
 que las estructuras informales sean irresponsables.  Aquellas que
 quieren mantener su influencia tratarán de ser responsables también.
-Pero el grupo no puede compeler esa responsabilidad ya que depende de
+Pero el grupo no puede forzar esa responsabilidad, depende de
 los intereses de la élite.
 
 
-# El sistema de "estrella"
+# El sistema de "estrellas"
 
 La idea de "la falta de estructura" ha creado el sistema de "estrellas".
 Vivimos en una sociedad que espera que los grupos políticos tomen las
 decisiones y que seleccionen personas que articulen esas decisiones para
 el público. La prensa y el público no saben cómo escuchar seriamente a
 mujeres individuales en tanto mujeres; quieren saber cómo se siente el
-grupo. Solo se han desarrollado tres técnicas para establecer opiniones
-grupales en forma masiva: el voto o referéndum, las encuestas de opinión
+grupo. Solo se han desarrollado tres técnicas para establecer la opinión
+de un grupo masivo: el voto o referéndum, las encuestas de opinión
 pública y la elección de voceras. El movimiento de liberación de las
 mujeres no ha utilizado ninguno de estos para comunicarse con el
 público. Tampoco el movimiento como un todo ni la mayoría de los
@@ -338,11 +339,11 @@ multitudinarios grupos dentro de este han establecido un medio para
 explicar sus posiciones sobre diversas cuestiones. Pero el público está
 condicionado a buscar voceras.
 
-Mientras no se ha elegido voceras conscientemente, el movimiento ha
+Aun cuando no se han elegido voceras conscientemente, el movimiento ha
 introducido muchas mujeres que han atrapado la atención del público por
 varias razones. Estas mujeres no representan a un grupo en particular o
 una opinión establecida; lo saben y usualmente así lo expresan. Pero
-debido a de que no hay voceras oficiales ni un cuerpo de toma de
+debido a que no hay voceras oficiales ni un cuerpo de toma de
 decisiones que la prensa pueda consultar cuando quiere saber la postura
 del movimiento frente a un tema, esas mujeres son percibidas como las
 voceras. Por ello, quieran o no, le guste al movimiento o no, las
@@ -355,7 +356,7 @@ cuando la prensa asume que hablan por el movimiento. Pero mientras que
 el movimiento no elija sus propias voceras, tales mujeres serán ubicadas
 en ese rol por la prensa y el público, a pesar de sus propios deseos.
 
-Esto tiene varias consecuencias negativas para ambos, el movimiento y
+Esto tiene varias consecuencias negativas tanto para el movimiento como para
 esas mujeres etiquetadas "estrellas". Primero, como el movimiento no es
 quien las coloca en el rol de voceras, este no puede sacarlas de allí.
 La prensa las coloca allí y solamente la prensa puede elegir dejar de
@@ -377,7 +378,7 @@ inclinarse ante ese tipo de presión personal. Es así que el contragolpe
 al sistema de "estrella" efectivamente anima el mismo tipo de
 irresponsabilidad individualista que el movimiento condena. Marginando a
 una hermana como "estrella", el movimiento pierde cualquier control que
-podría haber tenido sobre la persona que luego tiene la libertad de
+podría haber tenido sobre la persona, que luego tiene la libertad de
 cometer todos los pecados individualistas de los que ha sido acusada.
 
 
@@ -618,7 +619,7 @@ manera coordinada. Para hacer esto debe estar organizado --local,
 regional y nacionalmente.
 
 
-# Principios de estructuracion democrática
+# Principios de estructuración democrática
 
 Una vez que el movimiento ya no se aferre tenazmente a la ideología de
 la "falta de estructura," es libre de desarrollar esas formas de


### PR DESCRIPTION
Tengo que pasar el resto, y un par polémicas o galponeras que quería discutir:
1. cambiar todos los "las miembros" o similares por "las integrantes"
2. cambiar todos los "movimiento de liberación de mujeres" por "movimiento de liberación femenina"
